### PR TITLE
fixed chat默认的类型为模块而不是模块内的Chat类

### DIFF
--- a/zhipuai/_client.py
+++ b/zhipuai/_client.py
@@ -15,7 +15,7 @@ from httpx import Timeout
 
 
 class ZhipuAI(HttpClient):
-    chat: api_resource.chat
+    chat: api_resource.chat.Chat
     api_key: str
 
     def __init__(


### PR DESCRIPTION
调整chat类型定义，原先定义为模块，导致开启类型检查后，官方示例代码内的client.chat.completions与client.chat.asyncCompletions报错，chat上不存在completions、asyncCompletions